### PR TITLE
docs(org): add organization profile README

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -1,0 +1,28 @@
+# ctx-hub
+
+> Collaborative hub for experiments, freelancing tools, and idea management.
+
+**Repositories**
+- 🗂️ [ctx-meta](https://github.com/ctx-hub/ctx-meta) — meta koordinasiya & standartlar  
+- 🔬 [personal-labs](https://github.com/ctx-hub/personal-labs) — eksperimentlər & prototiplər  
+- 💼 [freelans-tracker](https://github.com/ctx-hub/freelans-tracker) — freelance işlər & izləmə  
+- 💡 [idea-vault](https://github.com/ctx-hub/idea-vault) — ideyalar & tədqiqat anbarı  
+- ⚙️ [.github](https://github.com/ctx-hub/.github) — org-wide defaultlar (issue/PR şablonları, profillər)
+
+---
+
+## 📊 Quick Stats
+![Top Language](https://img.shields.io/github/languages/top/ctx-hub/ctx-meta)
+![License](https://img.shields.io/github/license/ctx-hub/ctx-meta)
+![Open Issues](https://img.shields.io/github/issues/ctx-hub/ctx-meta)
+
+---
+
+## 🔗 Useful Links
+- Contribution guide: see individual repos’ `CONTRIBUTING.md`
+- Security policy: see individual repos’ `SECURITY.md`
+- Code of Conduct: see individual repos’ `CODE_OF_CONDUCT.md`
+
+---
+
+MIT Licensed • © ctx-hub


### PR DESCRIPTION
Adds `profile/README.md` to display a rich organization overview on ctx-hub’s landing page.